### PR TITLE
86 add button leads back to create form sidemenu

### DIFF
--- a/src/app/(create-form-page)/create-form/page.tsx
+++ b/src/app/(create-form-page)/create-form/page.tsx
@@ -47,7 +47,11 @@ function CreateFormPage() {
 
           {!isSideMenuNewBlocksOpen && <SideMenuFormBlocks />}
 
-          {isSideMenuNewBlocksOpen && <SideMenuNewFormBlocks />}
+          {isSideMenuNewBlocksOpen && (
+            <SideMenuNewFormBlocks
+              toggleSideMenuContent={toggleSideMenuContent}
+            />
+          )}
 
           {/* SIDE MENU TOGGLE PREVIEW BUTTON (ONLY MOBILE) */}
           {!isSideMenuNewBlocksOpen && (

--- a/src/app/_components/form/SideMenuNewFormBlocks.tsx
+++ b/src/app/_components/form/SideMenuNewFormBlocks.tsx
@@ -11,13 +11,11 @@ import styles from "./SideMenuNewFormBlocks.module.scss"
 import Text from "./form-sidebar-blocks/Text"
 import TextInput from "./form-sidebar-blocks/TextInput"
 
-interface toggleSideMenuContentProps {
+interface Props {
   toggleSideMenuContent: () => void
 }
 
-function SideMenuNewFormBlocks({
-  toggleSideMenuContent,
-}: toggleSideMenuContentProps) {
+function SideMenuNewFormBlocks({ toggleSideMenuContent }: Props) {
   const [selectedBlock, setSelectedBlock] = useState<string | null>(null)
 
   const handleFormBlockClick = (formBlock: string) => {
@@ -76,7 +74,9 @@ function SideMenuNewFormBlocks({
         </div>
       )}
 
-      {selectedBlock === "text" && <Text />}
+      {selectedBlock === "text" && (
+        <Text toggleSideMenuContent={toggleSideMenuContent} />
+      )}
       {selectedBlock === "textinput" && (
         <TextInput toggleSideMenuContent={toggleSideMenuContent} />
       )}

--- a/src/app/_components/form/SideMenuNewFormBlocks.tsx
+++ b/src/app/_components/form/SideMenuNewFormBlocks.tsx
@@ -11,7 +11,13 @@ import styles from "./SideMenuNewFormBlocks.module.scss"
 import Text from "./form-sidebar-blocks/Text"
 import TextInput from "./form-sidebar-blocks/TextInput"
 
-function SideMenuNewFormBlocks() {
+interface toggleSideMenuContentProps {
+  toggleSideMenuContent: () => void
+}
+
+function SideMenuNewFormBlocks({
+  toggleSideMenuContent,
+}: toggleSideMenuContentProps) {
   const [selectedBlock, setSelectedBlock] = useState<string | null>(null)
 
   const handleFormBlockClick = (formBlock: string) => {
@@ -71,7 +77,9 @@ function SideMenuNewFormBlocks() {
       )}
 
       {selectedBlock === "text" && <Text />}
-      {selectedBlock === "textinput" && <TextInput />}
+      {selectedBlock === "textinput" && (
+        <TextInput toggleSideMenuContent={toggleSideMenuContent} />
+      )}
     </div>
   )
 }

--- a/src/app/_components/form/form-sidebar-blocks/Text.tsx
+++ b/src/app/_components/form/form-sidebar-blocks/Text.tsx
@@ -4,7 +4,11 @@ import { useForm } from "~/contexts/FormContext"
 import Button, { IconType } from "../../Button"
 import styles from "./Text.module.scss"
 
-function Text() {
+interface Props {
+  toggleSideMenuContent: () => void
+}
+
+function Text({ toggleSideMenuContent }: Props) {
   const { addFormBlock } = useForm()
   const [blockText, setBlockText] = useState<string>("")
   const [orderNumber, setOrderNumber] = useState<number>(0)
@@ -36,7 +40,13 @@ function Text() {
         value={blockText}
         onChange={e => setBlockText(e.target.value)}
       ></textarea>
-      <Button icon={IconType.None} onClick={handleClick}>
+      <Button
+        icon={IconType.None}
+        onClick={() => {
+          handleClick()
+          toggleSideMenuContent()
+        }}
+      >
         Add block
       </Button>
     </div>

--- a/src/app/_components/form/form-sidebar-blocks/TextInput.tsx
+++ b/src/app/_components/form/form-sidebar-blocks/TextInput.tsx
@@ -8,11 +8,11 @@ import styles from "./TextInput.module.scss"
 // Button skall skicka block till createform
 // block skall ha med id, title, type, order, formid, required
 
-interface toggleSideMenuContentProps {
+interface Props {
   toggleSideMenuContent: () => void
 }
 
-function TextInput({ toggleSideMenuContent }: toggleSideMenuContentProps) {
+function TextInput({ toggleSideMenuContent }: Props) {
   const [blockTitle, setBlockTitle] = useState<string>("")
   const { addFormBlock } = useForm()
   const [orderNumber, setOrderNumber] = useState<number>(0)

--- a/src/app/_components/form/form-sidebar-blocks/TextInput.tsx
+++ b/src/app/_components/form/form-sidebar-blocks/TextInput.tsx
@@ -8,7 +8,11 @@ import styles from "./TextInput.module.scss"
 // Button skall skicka block till createform
 // block skall ha med id, title, type, order, formid, required
 
-function TextInput() {
+interface toggleSideMenuContentProps {
+  toggleSideMenuContent: () => void
+}
+
+function TextInput({ toggleSideMenuContent }: toggleSideMenuContentProps) {
   const [blockTitle, setBlockTitle] = useState<string>("")
   const { addFormBlock } = useForm()
   const [orderNumber, setOrderNumber] = useState<number>(0)
@@ -47,7 +51,10 @@ function TextInput() {
         <Button
           icon={IconType.None}
           className={styles.iconStyle}
-          onClick={handleClick}
+          onClick={() => {
+            handleClick()
+            toggleSideMenuContent()
+          }}
         >
           Add block
         </Button>


### PR DESCRIPTION
Nu togglas man tillbaka till sido menyn när man klicka på "add block" på text och textinput blocken.

![OhWellFineGIF](https://github.com/Sillen00/GlobalForm-Solutions/assets/114336470/46c5e60f-9acd-4312-84f3-da705c5f7bd1)
