### PR TITLE
Link samt "form-details" sidan med dynamisk [formid] routeing skapad.

### DIFF
--- a/src/app/(pages-with-header-and-footer)/dashboard/page.tsx
+++ b/src/app/(pages-with-header-and-footer)/dashboard/page.tsx
@@ -29,13 +29,15 @@ function DashboardPage() {
           </Link>
           {forms
             ? forms.map(form => (
-                <FormCard
-                  key={form.id}
-                  date={form.startDate}
-                  time={form.startTime}
-                  title={form.title}
-                  place={form.location}
-                />
+                <Link href={`/form-details/${form.id}`} key={form.id}>
+                  <FormCard
+                    key={form.id}
+                    date={form.startDate}
+                    time={form.startTime}
+                    title={form.title}
+                    place={form.location}
+                  />
+                </Link>
               ))
             : "No forms created yet"}
         </div>

--- a/src/app/(pages-with-header-and-footer)/form-details/[formid]/page.tsx
+++ b/src/app/(pages-with-header-and-footer)/form-details/[formid]/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+import { useParams } from "next/navigation"
+
+function FormDetalPage() {
+  const params = useParams<{ formid: string }>()
+
+  return (
+    <div>
+      <h1>FormDetalPage</h1>
+      <h2>form id: {params.formid}</h2>
+    </div>
+  )
+}
+
+export default FormDetalPage


### PR DESCRIPTION
Man kan nu klicka på något av form korten i dashboarden och hamna på "form-details" sidan för det specifika formuläret.