### PR TITLE
94 styla dashboard page correkt

### DIFF
--- a/src/app/(pages-with-header-and-footer)/dashboard/page.scss
+++ b/src/app/(pages-with-header-and-footer)/dashboard/page.scss
@@ -1,6 +1,9 @@
 // DASHBOARD PAGE SCSS
 
 .dashboard-wrapper {
+
+  min-height: 60vh;
+
   h2 {
     font-size: 2rem;
     font-weight: bold;
@@ -9,12 +12,12 @@
 
   .form-card-container {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 20px;
+    justify-content: start;
     align-items: center;
-
+    
     .create-new-card {
-      min-width: 200px;
       min-height: 150px;
       background-color: var(--background-color-footer);
       border-radius: 10px;

--- a/src/app/(pages-with-header-and-footer)/layout.tsx
+++ b/src/app/(pages-with-header-and-footer)/layout.tsx
@@ -1,8 +1,10 @@
 import Footer from "../_components/Footer"
+import Header from "../_components/Header"
 
 const HeaderFooterLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
+      <Header />
       <div className='body-padding'>{children}</div>
       <Footer />
     </>

--- a/src/app/_components/DashboardFormCard.scss
+++ b/src/app/_components/DashboardFormCard.scss
@@ -1,7 +1,6 @@
 // FORM CARD SCSS
 
 .form-card {
-  min-width: 200px;
   min-height: 150px;
   background-color: var(--primary-color);
   border-radius: 10px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import "~/styles/globals.css"
 import { TRPCReactProvider } from "~/trpc/react"
 import FormContextProvider from "../contexts/FormContext"
 import "../styles/clerk.scss"
-import Header from "./_components/Header"
 
 const inter = Jura({
   subsets: ["latin"],
@@ -39,10 +38,7 @@ export default function RootLayout({
         <body className={`font-sans ${inter.variable}`}>
           <TRPCReactProvider cookies={cookies().toString()}>
             <FormContextProvider>
-              <div className='body-container'>
-                <Header />
-                {children}
-              </div>
+              <div className='body-container'>{children}</div>
             </FormContextProvider>
           </TRPCReactProvider>
         </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,11 +3,13 @@ import Image from "next/image"
 import Link from "next/link"
 import { IoCreateOutline } from "react-icons/io5"
 import Footer from "./_components/Footer"
+import Header from "./_components/Header"
 import "./page.scss"
 
 export default async function Home() {
   return (
     <>
+      <Header />
       <div className='body-padding'>
         <main>
           <div className='hero'>


### PR DESCRIPTION
Flyttade headern från root layouten till "(pages-with-header-and-footer)" mappen så att inte headern finns på login sidan.

Dashboard form korten har nu en max-width så att de inte sträcks över hela skärmen samt höjden på hela dashboard sidan har en min-height så att sidan tar upp hela skärmen.